### PR TITLE
Bug fixes for AskSonic when LAST FM isn't enabled and if Songs in album are unplayable.

### DIFF
--- a/asksonic/intents/playback.py
+++ b/asksonic/intents/playback.py
@@ -45,8 +45,13 @@ def playback_nearly_finished() -> Union[audio, tuple]:
 @ask.on_playback_finished()
 def playback_finished() -> tuple:
     log('Playback Finished')
-    if queue.current:
-        queue.current.scrobble(submission=True, timestamp=queue.start_time)
+    # This will exception out if last.fm is not setup
+    try:
+        if queue.current:
+            queue.current.scrobble(submission=True, timestamp=queue.start_time)
+    except:
+        pass
+        
     queue.next()
     return empty_response
 

--- a/asksonic/intents/playback.py
+++ b/asksonic/intents/playback.py
@@ -10,8 +10,13 @@ from asksonic.utils.response import empty_response, enqueue_track_response, \
 @ask.on_playback_started()
 def playback_started() -> tuple:
     log('Playback Started')
-    if queue.current:
-        queue.current.scrobble(submission=False, timestamp=queue.start_time)
+    # this will exception out if LAST FM isn't setup on sonic api
+    try:
+        if queue.current:
+            queue.current.scrobble(submission=False, timestamp=queue.start_time)
+    except:
+        pass
+        
     return empty_response
 
 

--- a/asksonic/utils/subsonic/api.py
+++ b/asksonic/utils/subsonic/api.py
@@ -96,14 +96,18 @@ class Subsonic(Connection):
             return []
         shuffle(albums)
         tracks = []
+        # Fix bug when it can't find album to play
         for album in albums:
-            songs = self.getAlbum(album['id'])
-            songs = songs['album']['song']
-            shuffle(songs)
-            tracks.extend([Track(**track) for track in songs])
-            if len(tracks) >= count:
-                tracks = tracks[:count]
-                break
+            try:
+                songs = self.getAlbum(album['id'])
+                songs = songs['album']['song']
+                shuffle(songs)
+                tracks.extend([Track(**track) for track in songs])
+                if len(tracks) >= count:
+                    tracks = tracks[:count]
+                    break
+            except:
+                continue
         shuffle(tracks)
         return tracks
 


### PR DESCRIPTION
Sometimes the api fails because the ID In subsonic is there but none of the songs are playable. and it comes back with the exception cannot find albumid.

Also if last.fm is not enabled it will come back with errors with the scrobble.
I added a try catch. This fixed the issue of songs not being played next, and sometimes songs not being played ast all

This was tested with the sonic player funkwhale.